### PR TITLE
bugfix in hash length check

### DIFF
--- a/client/query.go
+++ b/client/query.go
@@ -50,7 +50,7 @@ func (b *Bazaar) QueryRecent(amount int) (api.QueryResponse, error) {
 }
 
 func (b *Bazaar) QueryHash(hash string) (api.QueryResponse, error) {
-	if len(hash) != 64 || len(hash) != 32 || len(hash) != 128 {
+	if len(hash) != 64 && len(hash) != 32 && len(hash) != 128 {
 		return api.QueryResponse{}, errors.New("the hash must be SHA-256, SHA-1, or MD5")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/LloydLabs/go-malwarebazaar
+module github.com/Apr4h/go-malwarebazaar
 
 go 1.18
 


### PR DESCRIPTION
the QueryHash() function in query.go incorrectly checked the length of the hash - always resulted in an error. Logical OR replaced with logical AND